### PR TITLE
Add pkgdown author profiles

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -11,7 +11,6 @@ authors:
     href: "https://github.com/WillyRay"
   "George Vega Yon":
     href: "https://ggvy.cl"
-    html: "<img src='https://ggvy.cl/img/george-g-vega-yon-university-of-utah.webp' width=72 alt=''>"
 
 articles:
 - title: Tutorials

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,17 @@ url: https://epiforesite.github.io/multigroup-vaccine
 template:
   bootstrap: 5
 
+authors:
+  "Damon Toth":
+    href: "https://orcid.org/0000-0001-7393-4814"
+  "Jake Wagoner":
+    href: "https://github.com/JakeWags"
+  "Willy Ray":
+    href: "https://github.com/WillyRay"
+  "George Vega Yon":
+    href: "https://ggvy.cl"
+    html: "<img src='https://ggvy.cl/img/george-g-vega-yon-university-of-utah.webp' width=72 alt=''>"
+
 articles:
 - title: Tutorials
   contents:


### PR DESCRIPTION
## Summary

- link George Vega Yon to https://ggvy.cl while preserving his displayed name
- add profile links for every package author listed in DESCRIPTION
- add a source pkgdown configuration where the published site did not already have one

## Validation

- loaded the package metadata with pkgdown
- verified exact author-name matching against DESCRIPTION
- verified every configured author mapping contains only an href attribute

Related to gvegayon/website#32.